### PR TITLE
Fix services to work in Windows

### DIFF
--- a/systemd/kube-apiserver.service
+++ b/systemd/kube-apiserver.service
@@ -7,17 +7,7 @@ After=etcd.service
 [Service]
 EnvironmentFile=-/etc/kubernetes/config
 EnvironmentFile=-/etc/kubernetes/apiserver
-ExecStart=/usr/bin/kube-apiserver \
-	    $KUBE_LOGTOSTDERR \
-	    $KUBE_LOG_LEVEL \
-	    $KUBE_ETCD_SERVERS \
-	    $KUBE_API_ADDRESS \
-	    $KUBE_API_PORT \
-	    $KUBELET_PORT \
-	    $KUBE_ALLOW_PRIV \
-	    $KUBE_SERVICE_ADDRESSES \
-	    $KUBE_ADMISSION_CONTROL \
-	    $KUBE_API_ARGS
+ExecStart=/usr/bin/kube-apiserver $KUBE_LOGTOSTDERR $KUBE_LOG_LEVEL $KUBE_ETCD_SERVERS $KUBE_API_ADDRESS $KUBE_API_PORT $KUBELET_PORT $KUBE_ALLOW_PRIV $KUBE_SERVICE_ADDRESSES $KUBE_ADMISSION_CONTROL $KUBE_API_ARGS
 Restart=on-failure
 Type=notify
 LimitNOFILE=65536

--- a/systemd/kube-controller-manager.service
+++ b/systemd/kube-controller-manager.service
@@ -5,11 +5,7 @@ Documentation=https://github.com/GoogleCloudPlatform/kubernetes
 [Service]
 EnvironmentFile=-/etc/kubernetes/config
 EnvironmentFile=-/etc/kubernetes/controller-manager
-ExecStart=/usr/bin/kube-controller-manager \
-        $KUBE_LOGTOSTDERR \
-        $KUBE_LOG_LEVEL \
-        $KUBE_MASTER \
-        $KUBE_CONTROLLER_MANAGER_ARGS
+ExecStart=/usr/bin/kube-controller-manager $KUBE_LOGTOSTDERR $KUBE_LOG_LEVEL $KUBE_MASTER $KUBE_CONTROLLER_MANAGER_ARGS
 Restart=on-failure
 LimitNOFILE=65536
 

--- a/systemd/kube-proxy.service
+++ b/systemd/kube-proxy.service
@@ -6,11 +6,7 @@ After=network.target
 [Service]
 EnvironmentFile=-/etc/kubernetes/config
 EnvironmentFile=-/etc/kubernetes/proxy
-ExecStart=/usr/bin/kube-proxy \
-        $KUBE_LOGTOSTDERR \
-        $KUBE_LOG_LEVEL \
-        $KUBE_MASTER \
-        $KUBE_PROXY_ARGS
+ExecStart=/usr/bin/kube-proxy $KUBE_LOGTOSTDERR $KUBE_LOG_LEVEL $KUBE_MASTER $KUBE_PROXY_ARGS
 Restart=on-failure
 LimitNOFILE=65536
 

--- a/systemd/kube-scheduler.service
+++ b/systemd/kube-scheduler.service
@@ -5,12 +5,7 @@ Documentation=https://github.com/GoogleCloudPlatform/kubernetes
 [Service]
 EnvironmentFile=-/etc/kubernetes/config
 EnvironmentFile=-/etc/kubernetes/scheduler
-ExecStart=/usr/bin/kube-scheduler \
-            $KUBE_LOGTOSTDERR \
-            $KUBE_LOG_LEVEL \
-            $KUBE_MASTER \
-            $KUBE_SCHEDULER_CONF \
-            $KUBE_SCHEDULER_ARGS
+ExecStart=/usr/bin/kube-scheduler $KUBE_LOGTOSTDERR $KUBE_LOG_LEVEL $KUBE_MASTER $KUBE_SCHEDULER_CONF $KUBE_SCHEDULER_ARGS
 Restart=on-failure
 LimitNOFILE=65536
 

--- a/systemd/kubelet.service
+++ b/systemd/kubelet.service
@@ -8,16 +8,7 @@ Requires=docker.service
 WorkingDirectory=/var/lib/kubelet
 EnvironmentFile=-/etc/kubernetes/config
 EnvironmentFile=-/etc/kubernetes/kubelet
-ExecStart=/usr/bin/kubelet \
-            $KUBE_LOGTOSTDERR \
-            $KUBE_LOG_LEVEL \
-            $KUBELET_API_SERVER \
-            $KUBELET_ADDRESS \
-            $KUBELET_PORT \
-            $KUBELET_HOSTNAME \
-            $KUBE_ALLOW_PRIV \
-            $KUBELET_POD_INFRA_CONTAINER \
-            $KUBELET_ARGS
+ExecStart=/usr/bin/kubelet $KUBE_LOGTOSTDERR $KUBE_LOG_LEVEL $KUBELET_API_SERVER $KUBELET_ADDRESS $KUBELET_PORT $KUBELET_HOSTNAME $KUBE_ALLOW_PRIV $KUBELET_POD_INFRA_CONTAINER $KUBELET_ARGS
 Restart=on-failure
 
 [Install]


### PR DESCRIPTION
Hi,

I had an issue to deploy this with windows.

To fix the issue I needed edit the services and put ExecStart in one line.

```
D:\Work\Projects\Personal\kubernetes-vagrant-centos-cluster (master -> origin)
λ vagrant --version
Vagrant 2.1.1
D:\Work\Projects\Personal\kubernetes-vagrant-centos-cluster (master -> origin)
λ ls
ISSUE_TEMPLATE.md  LICENSE  README-cn.md  README.md  Vagrantfile  addon/  conf/  hack/  images/  node1/  node2/  node3/  pki/  systemd/  yaml/  yum/
    node1: configure master and node1
    node1: Failed to execute operation: Bad message
    node1: Failed to start kube-apiserver.service: Unit is not loaded properly: Bad message.
    node1: See system logs and 'systemctl status kube-apiserver.service' for details.
    node1: Failed to execute operation: Bad message
    node1: Failed to start kube-controller-manager.service: Unit is not loaded properly: Bad message.
    node1: See system logs and 'systemctl status kube-controller-manager.service' for details.
    node1: Failed to execute operation: Bad message
    node1: Failed to start kube-scheduler.service: Unit is not loaded properly: Bad message.
    node1: See system logs and 'systemctl status kube-scheduler.service' for details.
    node1: Failed to execute operation: Bad message
    node1: Failed to start kubelet.service: Unit is not loaded properly: Bad message.
    node1: See system logs and 'systemctl status kubelet.service' for details.
    node1: Failed to execute operation: Bad message
    node1: Failed to start kube-proxy.service: Unit is not loaded properly: Bad message.
    node1: See system logs and 'systemctl status kube-proxy.service' for details.
[vagrant@node1 ~]$ systemctl status kube-controller-manager.service
● kube-controller-manager.service - Kubernetes Controller Manager
   Loaded: error (Reason: Bad message)
   Active: inactive (dead)
     Docs: https://github.com/GoogleCloudPlatform/kubernetes
[vagrant@node1 ~]$ systemctl status kube-scheduler.service
● kube-scheduler.service - Kubernetes Scheduler Plugin
   Loaded: error (Reason: Bad message)
   Active: inactive (dead)
     Docs: https://github.com/GoogleCloudPlatform/kubernetes
[vagrant@node1 ~]$ sudo journalctl -u kube-scheduler.service
-- Logs begin at Fri 2018-10-26 04:23:26 CST, end at Fri 2018-10-26 04:32:03 CST. --
Oct 26 04:28:13 node1 systemd[1]: [/usr/lib/systemd/system/kube-scheduler.service:8] Trailing garbage, ignoring.
Oct 26 04:28:13 node1 systemd[1]: [/usr/lib/systemd/system/kube-scheduler.service:9] Missing '='.
Oct 26 04:28:13 node1 systemd[1]: [/usr/lib/systemd/system/kube-scheduler.service:8] Trailing garbage, ignoring.
Oct 26 04:28:13 node1 systemd[1]: [/usr/lib/systemd/system/kube-scheduler.service:9] Missing '='.
Oct 26 04:31:28 node1 systemd[1]: [/usr/lib/systemd/system/kube-scheduler.service:8] Trailing garbage, ignoring.
Oct 26 04:31:28 node1 systemd[1]: [/usr/lib/systemd/system/kube-scheduler.service:9] Missing '='.
[vagrant@node1 ~]$
```
