### PR TITLE
Fix for issue #50: replace CRLF with LF in systemd unit files

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -89,7 +89,7 @@ Vagrant.configure("2") do |config|
         mv /etc/yum.repos.d/CentOS7-Base-163.repo /etc/yum.repos.d/CentOS-Base.repo
         # using socat to port forward in helm tiller
         # install  kmod and ceph-common for rook
-        yum install -y wget curl conntrack-tools vim net-tools socat ntp kmod ceph-common
+        yum install -y wget curl conntrack-tools vim net-tools socat ntp kmod ceph-common dos2unix
         # enable ntp to sync time
         echo 'sync time'
         systemctl start ntpd
@@ -208,6 +208,7 @@ EOF
         tar -xzvf /vagrant/kubernetes-server-linux-amd64.tar.gz -C /vagrant
         cp /vagrant/kubernetes/server/bin/* /usr/bin
 
+        dos2unix -q /vagrant/systemd/*.service
         cp /vagrant/systemd/*.service /usr/lib/systemd/system/
         mkdir -p /var/lib/kubelet
         mkdir -p ~/.kube


### PR DESCRIPTION
@rootsongjc : Please merge this PR to master. This PR fixes issue #50 

Updated Vagrantfile to install "dos2unix" utility inside CentOS VM, and use dos2unix to convert the systemd unit files from CRLF to LF. I have tested the fix; now the cluster is able to bootstrap successfully without any errors. No changes required in README.

This fix will work fine for Linux environment as well since dos2unix exits silently when the unit files have LF. So the fix is a universal fix. Please find below the output showing a successfully bootstrapped K8S cluster:-

```
$ vagrant ssh node1
[vagrant@node1 ~]$ sudo su
[root@node1 vagrant]# kubectl get nodes
NAME      STATUS    ROLES     AGE       VERSION
node1     Ready     <none>    36m       v1.11.0
node2     Ready     <none>    11m       v1.11.0
node3     Ready     <none>    1m        v1.11.0
```
