### PR TITLE
更新，基于kubernetes1.16.14版本的部署测试

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,5 @@
 .DS_Store
 *.tar.gz
 kubernetes
+*.box
+.idea/*

--- a/README-cn.md
+++ b/README-cn.md
@@ -17,9 +17,9 @@
 需要准备以下软件和环境：
 
 - 8G以上内存
-- Vagrant 2.0+（推荐使用 v2.0.2 版本）
+- Vagrant 最新版本（推荐2.2.16）
 - VirtualBox 5.2（不支持 5.2 以上的版本）
-- 提前下载Kubernetes 1.9以上版本（支持最新的1.15.0）的release压缩包
+- 提前下载Kubernetes 1.16（本篇基于1.16.14）的release压缩包
 - Mac/Linux，**Windows不完全支持，仅在windows10下通过**
 
 ## 集群
@@ -85,7 +85,7 @@ vagrant up
 
 ````bash
 wget -c http://cloud.centos.org/centos/7/vagrant/x86_64/images/CentOS-7-x86_64-Vagrant-1801_02.VirtualBox.box
-vagrant box add CentOS-7-x86_64-Vagrant-1801_02.VirtualBox.box --name centos/7
+vagrant box add CentOS-7-x86_64-Vagrant-1804_02.VirtualBox.box --name centos/7
 ````
 
 这样下次运行`vagrant up`的时候就会自动读取本地的`centos/7` box而不会再到网上下载。
@@ -158,7 +158,7 @@ dos2unix dns-deploy.sh
 要想在本地直接操作Kubernetes集群，需要在你的电脑里安装`kubectl`命令行工具，对于Mac用户执行以下步骤：
 
 ```bash
-wget https://storage.googleapis.com/kubernetes-release/release/v1.15.0/kubernetes-client-darwin-amd64.tar.gz
+wget https://storage.googleapis.com/kubernetes-release/release/v1.16.14/kubernetes-client-darwin-amd64.tar.gz
 tar xvf kubernetes-client-darwin-amd64.tar.gz && cp kubernetes/client/bin/kubectl /usr/local/bin
 ```
 

--- a/README.md
+++ b/README.md
@@ -39,9 +39,9 @@ The container network range is `170.33.0.0/16` owned by flanneld with `host-gw` 
 ### Prerequisite
 
 * Host server with 8G+ mem(More is better), 60G disk, 8 core cpu at lease
-* **Vagrant 2.0+（2.0.2 recommended）**
+* **Vagrant latest（2.2.16 recommended）**
 * **VirtualBox 5.2 (5.2+ is not supported)**
-* Kubernetes 1.9+ (support the latest version 1.15.0)
+* Kubernetes 1.16 (support the latest version 1.16.14)
 * Across GFW to download the kubernetes files (For China users only)
 * MacOS/Linux (**Windows is not supported completely**)
 * NFS Server Package 
@@ -91,7 +91,7 @@ If you have difficult to vagrant up the cluster because of have no way to downlo
 
 ```bash
 wget -c http://cloud.centos.org/centos/7/vagrant/x86_64/images/CentOS-7-x86_64-Vagrant-1801_02.VirtualBox.box
-vagrant box add CentOS-7-x86_64-Vagrant-1801_02.VirtualBox.box --name centos/7
+vagrant box add CentOS-7-x86_64-Vagrant-1804_02.VirtualBox.box --name centos/7
 ```
 
 The next time you run `vagrant up`, vagrant will import the local box automatically.
@@ -145,7 +145,7 @@ In order to manage the cluster on local you should Install `kubectl` command lin
 Go to [Kubernetes release notes](https://kubernetes.io/docs/setup/release/notes/), download the client binaries, unzip it and then move `kubectl`  to your `$PATH` folder, for MacOS:
 
 ```bash
-wget https://storage.googleapis.com/kubernetes-release/release/v1.15.0/kubernetes-client-darwin-amd64.tar.gz
+wget https://storage.googleapis.com/kubernetes-release/release/v1.16.14/kubernetes-client-darwin-amd64.tar.gz
 tar xvf kubernetes-client-darwin-amd64.tar.gz && cp kubernetes/client/bin/kubectl /usr/local/bin
 ```
 

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -1,18 +1,22 @@
 # -*- mode: ruby -*-
 # vi: set ft=ruby :
+# on win10, you need `vagrant plugin install vagrant-vbguest --plugin-version 0.21` and change synced_folder.type="virtualbox"
+# reference `https://www.dissmeyer.com/2020/02/11/issue-with-centos-7-vagrant-boxes-on-windows-10/`
+
 
 Vagrant.configure("2") do |config|
   config.vm.box_check_update = false
   config.vm.provider 'virtualbox' do |vb|
-   vb.customize [ "guestproperty", "set", :id, "/VirtualBox/GuestAdd/VBoxService/--timesync-set-threshold", 1000 ]
+  vb.customize [ "guestproperty", "set", :id, "/VirtualBox/GuestAdd/VBoxService/--timesync-set-threshold", 1000 ]
   end  
-  config.vm.synced_folder ".", "/vagrant", type: "rsync"
+  config.vm.synced_folder ".", "/vagrant", type: "virtualbox"
   $num_instances = 3
   # curl https://discovery.etcd.io/new?size=3
   $etcd_cluster = "node1=http://172.17.8.101:2380"
   (1..$num_instances).each do |i|
     config.vm.define "node#{i}" do |node|
       node.vm.box = "centos/7"
+      node.vm.box_version = "1804.02"
       node.vm.hostname = "node#{i}"
       ip = "172.17.8.#{i+100}"
       node.vm.network "private_network", ip: ip

--- a/addon/dashboard/kubernetes-dashboard.yaml
+++ b/addon/dashboard/kubernetes-dashboard.yaml
@@ -95,7 +95,7 @@ subjects:
 # ------------------- Dashboard Deployment ------------------- #
 
 kind: Deployment
-apiVersion: apps/v1beta2
+apiVersion: apps/v1
 metadata:
   labels:
     k8s-app: kubernetes-dashboard
@@ -117,7 +117,7 @@ spec:
         kubernetes.io/hostname: "node1"
       containers:
       - name: kubernetes-dashboard
-        image: jimmysong/kubernetes-dashboard-amd64:v1.8.3
+        image: registry.aliyuncs.com/google_containers/kubernetes-dashboard-amd64:v1.8.3
         ports:
         - containerPort: 8443
           protocol: TCP
@@ -164,8 +164,10 @@ metadata:
   name: kubernetes-dashboard
   namespace: kube-system
 spec:
+  type: NodePort
   ports:
     - port: 8443
       targetPort: 8443
+      nodePort: 30000
   selector:
     k8s-app: kubernetes-dashboard

--- a/addon/dns/coredns.yaml.sed
+++ b/addon/dns/coredns.yaml.sed
@@ -4,7 +4,7 @@ metadata:
   name: coredns
   namespace: kube-system
 ---
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   labels:
@@ -22,7 +22,7 @@ rules:
   - list
   - watch
 ---
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   annotations:
@@ -61,7 +61,7 @@ data:
         loadbalance
     }
 ---
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: coredns

--- a/addon/efk/kibana-deployment.yaml
+++ b/addon/efk/kibana-deployment.yaml
@@ -19,7 +19,8 @@ spec:
     spec:
       containers:
       - name: kibana-logging
-        image: jimmysong/kibana:5.6.4
+        #image: jimmysong/kibana:5.6.4
+        image: trojany/kibana:5.6.4
         resources:
           # need more cpu upon initialization, therefore burstable class
           limits:

--- a/addon/heapster/grafana-service.yaml
+++ b/addon/heapster/grafana-service.yaml
@@ -15,6 +15,7 @@ spec:
     - port: 3000
       protocol: TCP
       targetPort: ui
+      nodePort: 30001
   selector:
     k8s-app: influxGrafana
-#  type: NodePort
+  type: NodePort

--- a/addon/heapster/heapster-controller.yaml
+++ b/addon/heapster/heapster-controller.yaml
@@ -46,7 +46,7 @@ data:
     apiVersion: nannyconfig/v1alpha1
     kind: NannyConfiguration
 ---
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: heapster-v1.5.0

--- a/addon/heapster/influxdb-grafana-controller.yaml
+++ b/addon/heapster/influxdb-grafana-controller.yaml
@@ -1,5 +1,5 @@
 kind: Deployment
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 metadata:
   name: monitoring-influxdb-grafana-v4
   namespace: kube-system
@@ -29,7 +29,8 @@ spec:
         operator: "Exists"
       containers:
         - name: influxdb
-          image: jimmysong/heapster-influxdb-amd64:v1.3.3
+          #image: jimmysong/heapster-influxdb-amd64:v1.3.3
+          image: pupudaye/heapster-influxdb-amd64:v1.3.3
           resources:
             limits:
               cpu: 100m

--- a/addon/traefik-ingress/traefik.yaml
+++ b/addon/traefik-ingress/traefik.yaml
@@ -6,13 +6,16 @@ metadata:
   namespace: kube-system
 ---
 kind: DaemonSet
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 metadata:
   name: traefik-ingress-controller
   namespace: kube-system
   labels:
     k8s-app: traefik-ingress-lb
 spec:
+  selector:
+    matchLabels:
+      name: traefik-ingress-lb
   template:
     metadata:
       labels:

--- a/install.sh
+++ b/install.sh
@@ -11,7 +11,7 @@ yum install -y wget curl conntrack-tools vim net-tools telnet tcpdump bind-utils
 kubernetes_release="/vagrant/kubernetes-server-linux-amd64.tar.gz"
 # Download Kubernetes
 if [[ $(hostname) == "node1" ]] && [[ ! -f "$kubernetes_release" ]]; then
-    wget https://storage.googleapis.com/kubernetes-release/release/v1.15.0/kubernetes-server-linux-amd64.tar.gz -P /vagrant/
+    wget https://storage.googleapis.com/kubernetes-release/release/v1.16.14/kubernetes-server-linux-amd64.tar.gz -P /vagrant/
 fi
 
 # enable ntp to sync time

--- a/node1/kubelet
+++ b/node1/kubelet
@@ -15,7 +15,7 @@ KUBELET_HOSTNAME="--hostname-override=node1"
 # KUBELET_API_SERVER="--api-servers=http://172.20.0.113:8080"
 #
 ## pod infrastructure container
-KUBELET_POD_INFRA_CONTAINER="--pod-infra-container-image=jimmysong/pause-amd64:3.0"
+KUBELET_POD_INFRA_CONTAINER="--pod-infra-container-image=registry.aliyuncs.com/google_containers/pause:3.1"
 #
 ## Add your own!
 KUBELET_ARGS="--runtime-cgroups=/systemd/system.slice --kubelet-cgroups=/systemd/system.slice --cgroup-driver=systemd --cluster-dns=10.254.0.2 --bootstrap-kubeconfig=/etc/kubernetes/bootstrap.kubeconfig --kubeconfig=/etc/kubernetes/kubelet.kubeconfig --cert-dir=/etc/kubernetes/ssl --cluster-domain=cluster.local --hairpin-mode promiscuous-bridge --serialize-image-pulls=false"

--- a/node2/kubelet
+++ b/node2/kubelet
@@ -16,7 +16,8 @@ KUBELET_HOSTNAME="--hostname-override=node2"
 #
 ## pod infrastructure container
 #KUBELET_POD_INFRA_CONTAINER="--pod-infra-container-image=sz-pg-oam-docker-hub-001.tenxcloud.com/library/pod-infrastructure:rhel7"
-KUBELET_POD_INFRA_CONTAINER="--pod-infra-container-image=jimmysong/pause-amd64:3.0"
+#KUBELET_POD_INFRA_CONTAINER="--pod-infra-container-image=jimmysong/pause-amd64:3.0"
+KUBELET_POD_INFRA_CONTAINER="--pod-infra-container-image=registry.aliyuncs.com/google_containers/pause:3.1"
 #
 ## Add your own!
 KUBELET_ARGS="--runtime-cgroups=/systemd/system.slice --kubelet-cgroups=/systemd/system.slice --cgroup-driver=systemd --cluster-dns=10.254.0.2 --bootstrap-kubeconfig=/etc/kubernetes/bootstrap.kubeconfig --kubeconfig=/etc/kubernetes/kubelet.kubeconfig --cert-dir=/etc/kubernetes/ssl --cluster-domain=cluster.local --hairpin-mode promiscuous-bridge --serialize-image-pulls=false"

--- a/node3/kubelet
+++ b/node3/kubelet
@@ -15,7 +15,8 @@ KUBELET_HOSTNAME="--hostname-override=node3"
 # KUBELET_API_SERVER="--api-servers=http://172.20.0.113:8080"
 #
 ## pod infrastructure container
-KUBELET_POD_INFRA_CONTAINER="--pod-infra-container-image=jimmysong/pause-amd64:3.0"
+#KUBELET_POD_INFRA_CONTAINER="--pod-infra-container-image=jimmysong/pause-amd64:3.0"
+KUBELET_POD_INFRA_CONTAINER="--pod-infra-container-image=registry.aliyuncs.com/google_containers/pause:3.1"
 #
 ## Add your own!
 KUBELET_ARGS="--runtime-cgroups=/systemd/system.slice --kubelet-cgroups=/systemd/system.slice --cgroup-driver=systemd --cluster-dns=10.254.0.2 --bootstrap-kubeconfig=/etc/kubernetes/bootstrap.kubeconfig --kubeconfig=/etc/kubernetes/kubelet.kubeconfig --cert-dir=/etc/kubernetes/ssl --cluster-domain=cluster.local --hairpin-mode promiscuous-bridge --serialize-image-pulls=false"


### PR DESCRIPTION
1、基于win10+virtualbox+vagrant 2.2.16(最新版本)
2、更新对kubernetes1.16.14版本的部署测试
3、许多部署镜像已经访问不了了，做了相应的修改
