### PR TITLE
Add allow_kernel_upgrade=true for vbguest

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -16,6 +16,7 @@ Vagrant.configure("2") do |config|
   (1..$num_instances).each do |i|
     config.vm.define "node#{i}" do |node|
       node.vm.box = "centos/7"
+      node.vbguest.installer_options = { allow_kernel_upgrade: true }
       node.vm.box_version = "1804.02"
       node.vm.hostname = "node#{i}"
       ip = "172.17.8.#{i+100}"


### PR DESCRIPTION
According to [vbguest: installer-specific-options-installer_options](https://github.com/dotless-de/vagrant-vbguest#installer-specific-options-installer_options) suggestion for cluster environment, turn on the kernel upgrade option.